### PR TITLE
 Added validation for same pickup & dest. address

### DIFF
--- a/lib/screens/select_route.dart
+++ b/lib/screens/select_route.dart
@@ -251,14 +251,14 @@ class _SelectRouteState extends State<SelectRoute> {
                             errormsg = "Pickup or Destination address can't be Empty!";
                           }
                           else if (toValue==null) {
-                            print(toValue);
+
                             errormsg = "Destination address missing";
                           } else if (fromValue==null) {
-                            print(toValue);
+                            
                             errormsg = "PickUp address missing";
                           }
                           else if(fromValue==toValue){
-                            print(toValue);
+                            
                             errormsg = "PickUp address and Destination address must be different";
                           }
                           else

--- a/lib/screens/select_route.dart
+++ b/lib/screens/select_route.dart
@@ -247,11 +247,22 @@ class _SelectRouteState extends State<SelectRoute> {
                       height: 50,
                       child: ElevatedButton(
                         onPressed: () {
-                          if (toValue == "") {
+                          if(toValue==null && fromValue==null){
+                            errormsg = "Pickup or Destination address can't be Empty!";
+                          }
+                          else if (toValue==null) {
+                            print(toValue);
                             errormsg = "Destination address missing";
-                          } else if (fromValue == "") {
+                          } else if (fromValue==null) {
+                            print(toValue);
                             errormsg = "PickUp address missing";
-                          } else {
+                          }
+                          else if(fromValue==toValue){
+                            print(toValue);
+                            errormsg = "PickUp address and Destination address must be different";
+                          }
+                          else
+                          {
                             errormsg = "";
                           }
                           if (errormsg == "") {
@@ -265,7 +276,7 @@ class _SelectRouteState extends State<SelectRoute> {
                             Fluttertoast.showToast(
                                 msg: errormsg!,
                                 toastLength: Toast.LENGTH_SHORT,
-                                gravity: ToastGravity.CENTER,
+                                gravity: ToastGravity.BOTTOM,
                                 timeInSecForIosWeb: 1);
                           }
                           // Navigator.pushReplacement(context, MaterialPageRoute(builder: (context) => MainPage()));


### PR DESCRIPTION
Once we set a from or pickup location, the location should not be displayed in the to or drop location selection dropdown but as of now, its shown and people can simply select both as same locations and send a request.


User can't send request even he/she select same locations from drop down.